### PR TITLE
Refactor/replace tflit/pyxdg

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -20,17 +20,13 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt install python3-dev swig libssl-dev libfann-dev portaudio19-dev libpulse-dev
+          sudo apt install python3-dev swig portaudio19-dev
       - name: Build Source Packages
           run: |
             python setup.py sdist
       - name: Build Distribution Packages
         run: |
           python setup.py bdist_wheel
-      - name: Install tflite_runtime workaround tflit bug
-        run: |
-          pip3 install numpy
-          pip3 install --extra-index-url https://google-coral.github.io/py-repo/ tflite_runtime
       - name: Install core repo
         run: |
-          pip install .[audio-backend,mark1,stt,tts,skills_minimal,skills,gui,bus,all]
+          pip install .

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt install python3-dev swig libssl-dev
+          sudo apt install python3-dev swig portaudio19-dev
       - name: Install core repo
         run: |
           pip install .

--- a/ovos_ww_plugin_precise_lite/__init__.py
+++ b/ovos_ww_plugin_precise_lite/__init__.py
@@ -4,7 +4,7 @@ from ovos_utils.log import LOG
 import requests
 from os import makedirs
 from precise_lite_runner import PreciseLiteListener, ReadWriteStream
-from xdg import BaseDirectory as XDG
+from ovos_utils.xdg_utils import xdg_data_home
 
 
 class PreciseLiteHotwordPlugin(HotWordEngine):
@@ -43,7 +43,7 @@ class PreciseLiteHotwordPlugin(HotWordEngine):
     @staticmethod
     def download_model(url):
         name = url.split("/")[-1].split(".")[0] + ".tflite"
-        folder = join(XDG.xdg_data_home, "precise-lite")
+        folder = join(xdg_data_home(), "precise-lite")
         model_path = join(folder, name)
         if not isfile(model_path):
             LOG.info("Downloading model for precise-lite:")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-precise_lite_runner>=0.3.2
-pyxdg>=0.26
-ovos-plugin-manager~=0.0.2
+precise_lite_runner~=0.4
+ovos-plugin-manager~=0.0.4a2
+ovos-utils~=0.0.14a7

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python3
 from setuptools import setup
 
-
 PLUGIN_ENTRY_POINT = 'ovos-precise-lite=ovos_ww_plugin_precise_lite:PreciseLiteHotwordPlugin'
 setup(
     name='ovos-ww-plugin-precise-lite',
-    version='0.1.0',
+    version='0.1.1',
     description='A wake word plugin for OpenVoiceOS',
     url='https://github.com/OpenVoiceOS/ovos-ww-plugin-precise-lite',
     author='JarbasAi',
     author_email='jarbasai@mailfence.com',
     license='Apache-2.0',
     packages=['ovos_ww_plugin_precise_lite'],
-    install_requires=["precise_lite_runner>=0.3.2",
-                      "ovos-plugin-manager>~0.0.2",
-                      "pyxdg>=0.26"],
+    install_requires=["precise_lite_runner~=0.4",
+                      "ovos-utils~=0.0.14a7",
+                      "ovos-plugin-manager~=0.0.4a2"],
     zip_safe=True,
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/test/license_tests.py
+++ b/test/license_tests.py
@@ -6,11 +6,10 @@ from lichecker import LicenseChecker
 # these packages dont define license in setup.py
 # manually verified and injected
 license_overrides = {
+    'ptyprocess': 'ISC',
     "kthread": "MIT",
-    'yt-dlp': "Unlicense",
-    'pyxdg': 'GPL-2.0',
-    'ptyprocess': 'ISC license',
-    'psutil': 'BSD3'
+    "sonopy": "Apache-2.0",
+    "pyaudio": "MIT"
 }
 # explicitly allow these packages that would fail otherwise
 whitelist = []


### PR DESCRIPTION
bumps precise_lite_runner to 0.0.4 to replace tflit now that the main tflite_runtime package is on pypi

see https://github.com/OpenVoiceOS/precise_lite_runner/commit/d745cfe2d55f9de723ba0c341db520dd95cb6cd2

bumps ovos_utils and removes pyxdg dependency, see https://github.com/OpenVoiceOS/ovos-core/issues/51

updates github workflows